### PR TITLE
Turning on SO_REUSEADDR on server socket

### DIFF
--- a/src/tcptunnel.c
+++ b/src/tcptunnel.c
@@ -223,6 +223,13 @@ int build_server(void)
 		perror("build_server: socket()");
 		return 1;
 	}
+	
+	int optval = 1;
+	if(setsockopt(rc.server_socket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0)
+	{
+		perror("build_server: setsockopt(SO_REUSEADDR");
+		return 1;
+	}
 
 	if (settings.bind_address)
 	{


### PR DESCRIPTION
By turning on SO_REUSEADDR on the server socket, tcptunnel will be able to bind to a socket in the TIME_WAIT state. This makes tcptunnel succeed in binding the server socket if a previous connection was not disconnected properly.
