### PR TITLE
Added --client-addr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Options:
   --remote-port=PORT   remote port
   --remote-host=HOST   remote host
   --bind-address=IP    bind address
+  --client-addr=IP	Only accept connections from this IP address
   --buffer-size=BYTES  buffer size
   --fork               fork-based concurrency
   --log

--- a/configure
+++ b/configure
@@ -47,6 +47,7 @@ esac
 echo "checking host system type... $OS"
 
 PREFIX=`echo $PREFIX | sed 's#\/#\\\/#g'`
+LDFLAGS=`echo $LDFLAGS | sed 's#\/#\\\/#g'`
 
 sed -n -e "s/@PREFIX@/$PREFIX/g;" \
        -e "s/@LDFLAGS@/$LDFLAGS/g;" \

--- a/src/tcptunnel.c
+++ b/src/tcptunnel.c
@@ -280,7 +280,7 @@ int wait_for_clients(void)
 	if(settings.client_addr && (strcmp(inet_ntoa(rc.client_addr.sin_addr), options.client_addr) != 0)) {
 		if (settings.log)
 			printf("> %s tcptunnel: refused request request from %s\n", get_current_timestamp(), inet_ntoa(rc.client_addr.sin_addr));
-		close(rc.client.socket);
+		close(rc.client_socket);
 		return 1;
 	}
 

--- a/src/tcptunnel.c
+++ b/src/tcptunnel.c
@@ -473,6 +473,7 @@ Options:\n\
   --remote-port=PORT   remote port\n\
   --remote-host=HOST   remote host\n\
   --bind-address=IP    bind address\n\
+  --client-addr=IP     only accept connections from this address\n\
   --buffer-size=BYTES  buffer size\n"
 #ifndef __MINGW32__
 "  --fork               fork-based concurrency\n"

--- a/src/tcptunnel.c
+++ b/src/tcptunnel.c
@@ -48,8 +48,8 @@ static struct option long_options[] = {
 	{ "remote-host",   required_argument, NULL, REMOTE_HOST_OPTION },
 	{ "remote-port",   required_argument, NULL, REMOTE_PORT_OPTION },
 	{ "bind-address",  required_argument, NULL, BIND_ADDRESS_OPTION },
+	{ "client-address", required_argument, NULL, CLIENT_ADDRESS_OPTION },
 	{ "buffer-size",   required_argument, NULL, BUFFER_SIZE_OPTION },
-	{ "client-addr",   required_argument, NULL, CLIENT_ADDR_OPTION },
 #ifndef __MINGW32__
 	{ "fork",          no_argument,       NULL, FORK_OPTION },
 #endif
@@ -145,10 +145,12 @@ void set_options(int argc, char *argv[])
 				break;
 			}
 
-			case CLIENT_ADDR_OPTION:
-				options.client_addr = optarg;
-				settings.client_addr = 1;
+			case CLIENT_ADDRESS_OPTION:
+			{
+				options.client_address = optarg;
+				settings.client_address = 1;
 				break;
+			}
 
 			case FORK_OPTION:
 			{
@@ -277,9 +279,12 @@ int wait_for_clients(void)
 		return 1;
 	}
 
-	if(settings.client_addr && (strcmp(inet_ntoa(rc.client_addr.sin_addr), options.client_addr) != 0)) {
+	if(settings.client_address && (strcmp(inet_ntoa(rc.client_addr.sin_addr), options.client_address) != 0))
+	{
 		if (settings.log)
-			printf("> %s tcptunnel: refused request request from %s\n", get_current_timestamp(), inet_ntoa(rc.client_addr.sin_addr));
+		{
+			printf("> %s tcptunnel: refused request from %s\n", get_current_timestamp(), inet_ntoa(rc.client_addr.sin_addr));
+		}
 		close(rc.client_socket);
 		return 1;
 	}
@@ -473,7 +478,7 @@ Options:\n\
   --remote-port=PORT   remote port\n\
   --remote-host=HOST   remote host\n\
   --bind-address=IP    bind address\n\
-  --client-addr=IP     only accept connections from this address\n\
+  --client-address=IP  only accept connections from this address\n\
   --buffer-size=BYTES  buffer size\n"
 #ifndef __MINGW32__
 "  --fork               fork-based concurrency\n"

--- a/src/tcptunnel.c
+++ b/src/tcptunnel.c
@@ -41,7 +41,7 @@
 
 struct struct_rc rc;
 struct struct_options options;
-struct struct_settings settings = { 0, 0, 0, 0, 0, 0, 0, 0 };
+struct struct_settings settings = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 static struct option long_options[] = {
 	{ "local-port",    required_argument, NULL, LOCAL_PORT_OPTION },
@@ -49,6 +49,7 @@ static struct option long_options[] = {
 	{ "remote-port",   required_argument, NULL, REMOTE_PORT_OPTION },
 	{ "bind-address",  required_argument, NULL, BIND_ADDRESS_OPTION },
 	{ "buffer-size",   required_argument, NULL, BUFFER_SIZE_OPTION },
+	{ "client-addr",   required_argument, NULL, CLIENT_ADDR_OPTION },
 #ifndef __MINGW32__
 	{ "fork",          no_argument,       NULL, FORK_OPTION },
 #endif
@@ -143,6 +144,11 @@ void set_options(int argc, char *argv[])
 				settings.buffer_size = 1;
 				break;
 			}
+
+			case CLIENT_ADDR_OPTION:
+				options.client_addr = optarg;
+				settings.client_addr = 1;
+				break;
 
 			case FORK_OPTION:
 			{
@@ -268,6 +274,12 @@ int wait_for_clients(void)
 		{
 			perror("wait_for_clients: accept()");
 		}
+		return 1;
+	}
+
+	if(settings.client_addr && (strcmp(inet_ntoa(rc.client_addr.sin_addr), options.client_addr) != 0)) {
+		if (settings.log)
+			printf("> %s tcptunnel: refused request request from %s\n", get_current_timestamp(), inet_ntoa(rc.client_addr.sin_addr));
 		return 1;
 	}
 

--- a/src/tcptunnel.c
+++ b/src/tcptunnel.c
@@ -280,6 +280,7 @@ int wait_for_clients(void)
 	if(settings.client_addr && (strcmp(inet_ntoa(rc.client_addr.sin_addr), options.client_addr) != 0)) {
 		if (settings.log)
 			printf("> %s tcptunnel: refused request request from %s\n", get_current_timestamp(), inet_ntoa(rc.client_addr.sin_addr));
+		close(rc.client.socket);
 		return 1;
 	}
 

--- a/src/tcptunnel.h
+++ b/src/tcptunnel.h
@@ -13,6 +13,7 @@
 #define STAY_ALIVE_OPTION   'h'
 #define HELP_OPTION         'i'
 #define VERSION_OPTION      'j'
+#define	CLIENT_ADDR_OPTION  'k'
 
 #define PATH_SEPARATOR '/'
 
@@ -46,6 +47,7 @@ struct struct_settings {
 	unsigned int fork         : 1;
 	unsigned int log          : 1;
 	unsigned int stay_alive   : 1;
+	unsigned int client_addr  : 1;
 };
 
 struct struct_options {
@@ -53,6 +55,7 @@ struct struct_options {
 	char *remote_host;
 	char *remote_port;
 	char *bind_address;
+	const char *client_addr;
 	unsigned int buffer_size;
 };
 

--- a/src/tcptunnel.h
+++ b/src/tcptunnel.h
@@ -13,7 +13,7 @@
 #define STAY_ALIVE_OPTION   'h'
 #define HELP_OPTION         'i'
 #define VERSION_OPTION      'j'
-#define	CLIENT_ADDR_OPTION  'k'
+#define	CLIENT_ADDRESS_OPTION 'k'
 
 #define PATH_SEPARATOR '/'
 
@@ -47,7 +47,7 @@ struct struct_settings {
 	unsigned int fork         : 1;
 	unsigned int log          : 1;
 	unsigned int stay_alive   : 1;
-	unsigned int client_addr  : 1;
+	unsigned int client_address : 1;
 };
 
 struct struct_options {
@@ -55,7 +55,7 @@ struct struct_options {
 	char *remote_host;
 	char *remote_port;
 	char *bind_address;
-	const char *client_addr;
+	const char *client_address;
 	unsigned int buffer_size;
 };
 


### PR DESCRIPTION
With this only remote connections from the given IP address will be accepted.  My use case is an SMTP forward I'm using and I don't want it to be used as an open relay and I don't have the option of adding a firewall.